### PR TITLE
Use a separate name for the typed API protection cop to prevent configuration clashing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    package_protections (0.67.0)
+    package_protections (1.0.0)
       activesupport
       parse_packwerk
       rubocop

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The intent of this gem is two fold:
 This gem ships with the following checks
 1) Your package is not introducing dependencies that are not intended (via `packwerk` `enforce_dependencies`)
 2) Other packages are not using the private API of your package (via `packwerk` `enforce_privacy`)
-3) Your package has a typed public API (via the `rubocop` `Sorbet/StrictSigil` cop)
+3) Your package has a typed public API (via the `rubocop` `PackageProtections/TypedPublicApi` cop)
 4) Your package only creates a single namespace (via the `rubocop` `PackageProtections/NamespacedUnderPackageName` cop)
 4) Your package is only visible to a select number of packages (via the `packwerk` `enforce_privacy` cop)
 

--- a/lib/package_protections.rb
+++ b/lib/package_protections.rb
@@ -37,6 +37,7 @@ module PackageProtections
 
   # Implementation of rubocop-based protections
   require 'rubocop/cop/package_protections/namespaced_under_package_name'
+  require 'rubocop/cop/package_protections/typed_public_api'
 
   class << self
     extend T::Sig

--- a/lib/package_protections/private/typed_api_protection.rb
+++ b/lib/package_protections/private/typed_api_protection.rb
@@ -10,7 +10,7 @@ module PackageProtections
       include RubocopProtectionInterface
 
       IDENTIFIER = 'prevent_this_package_from_exposing_an_untyped_api'
-      COP_NAME = 'Sorbet/StrictSigil'
+      COP_NAME = 'PackageProtections/TypedPublicApi'
 
       sig { override.returns(String) }
       def identifier

--- a/lib/rubocop/cop/package_protections/typed_public_api.rb
+++ b/lib/rubocop/cop/package_protections/typed_public_api.rb
@@ -3,6 +3,18 @@
 module RuboCop
   module Cop
     module PackageProtections
+      #
+      # This inherits from `Sorbet::StrictSigil` and doesn't change any behavior of it.
+      # The only reason we do this is so that configuration for this cop can live under a different cop namespace.
+      # This prevents this cop's configuration from clashing with other configurations for the same cop.
+      # A concrete example of this would be if a user is using this package protection to make sure public APIs are typed,
+      # and separately the application as a whole requiring strict typing in certain parts of the application.
+      #
+      # To prevent problems associated with needing to manage identical configurations for the same cop, we simply call it
+      # something else in the context of this protection.
+      #
+      # We can apply this same pattern if we want to use other cops in the context of package protections and prevent clashing.
+      #
       class TypedPublicApi < Sorbet::StrictSigil
       end
     end

--- a/lib/rubocop/cop/package_protections/typed_public_api.rb
+++ b/lib/rubocop/cop/package_protections/typed_public_api.rb
@@ -1,0 +1,10 @@
+# typed: ignore
+
+module RuboCop
+  module Cop
+    module PackageProtections
+      class TypedPublicApi < Sorbet::StrictSigil
+      end
+    end
+  end
+end

--- a/package_protections.gemspec
+++ b/package_protections.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'package_protections'
-  spec.version       = '0.67.0'
+  spec.version       = '1.0.0'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['stephan.hagemann@gusto.com']
   spec.summary       = 'Package protections for Rails apps'

--- a/spec/package_protections_spec.rb
+++ b/spec/package_protections_spec.rb
@@ -579,7 +579,7 @@ describe PackageProtections do
         it 'has a helpful humanized description' do
           expected_humanized_message = <<~MESSAGE
             These files cannot have ANY Ruby files in the public API that are not typed strict or higher.
-            This is failing because these files are in `.rubocop_todo.yml` under `Sorbet/StrictSigil`.
+            This is failing because these files are in `.rubocop_todo.yml` under `PackageProtections/TypedPublicApi`.
             If you want to be able to ignore these files, you'll need to open the file's package's `package.yml` file and
             change `prevent_this_package_from_exposing_an_untyped_api` to `fail_on_new`
 
@@ -597,7 +597,7 @@ describe PackageProtections do
 
           it 'generates the expected rubocop.yml entries' do
             apples_package_yml_with_typed_api_protection_set_to_fail_never
-            cop_config = get_resulting_rubocop['Sorbet/StrictSigil']
+            cop_config = get_resulting_rubocop['PackageProtections/TypedPublicApi']
             expect(cop_config).to eq({ 'Enabled' => false })
           end
 
@@ -613,7 +613,7 @@ describe PackageProtections do
 
             write_file('packs/apples/app/public/tool.rb', '')
             write_file('.rubocop_todo.yml', <<~YML.strip)
-              Sorbet/StrictSigil:
+              PackageProtections/TypedPublicApi:
                 Exclude:
                   - packs/apples/app/public/tool.rb
             YML
@@ -630,7 +630,7 @@ describe PackageProtections do
 
           it 'generates the expected rubocop.yml entries' do
             apples_package_yml_with_typed_api_protection_set_to_fail_on_new
-            cop_config = get_resulting_rubocop['Sorbet/StrictSigil']
+            cop_config = get_resulting_rubocop['PackageProtections/TypedPublicApi']
             expect(cop_config['Exclude']).to eq(nil)
             expect(cop_config['Include']).to eq(['packs/apples/app/public/**/*'])
             expect(cop_config['Enabled']).to eq(true)
@@ -651,7 +651,7 @@ describe PackageProtections do
 
           it 'generates the expected rubocop.yml entries' do
             apples_package_yml_with_typed_api_protection_set_to_fail_on_any
-            cop_config = get_resulting_rubocop['Sorbet/StrictSigil']
+            cop_config = get_resulting_rubocop['PackageProtections/TypedPublicApi']
             expect(cop_config['Exclude']).to eq(nil)
             expect(cop_config['Include']).to eq(['packs/apples/app/public/**/*'])
             expect(cop_config['Enabled']).to eq(true)
@@ -669,7 +669,7 @@ describe PackageProtections do
             apples_package_yml_with_typed_api_protection_set_to_fail_on_any
             write_file('packs/apples/app/services/tool.rb', '')
             write_file('.rubocop_todo.yml', <<~YML.strip)
-              Sorbet/StrictSigil:
+              PackageProtections/TypedPublicApi:
                 Exclude:
                   - packs/apples/app/services/tool.rb
             YML
@@ -683,7 +683,7 @@ describe PackageProtections do
 
             write_file('packs/apples/app/public/tool.rb', '')
             write_file('.rubocop_todo.yml', <<~YML.strip)
-              Sorbet/StrictSigil:
+              PackageProtections/TypedPublicApi:
                 Exclude:
                   - packs/apples/app/public/tool.rb
             YML
@@ -701,7 +701,7 @@ describe PackageProtections do
 
             write_file('packs/apples/app/public/tool.rb', '')
             write_file('.rubocop_todo.yml', <<~YML.strip)
-              Sorbet/StrictSigil:
+              PackageProtections/TypedPublicApi:
                 Exclude:
                   - packs/other_pack/app/public/tool.rb
             YML


### PR DESCRIPTION
This PR changes the name of the cop that powers the typed API protection from using the default `Sorbet/StrictSigil` cop to `PackageProtections/TypedPublicApi` (which is just an alias for `Sorbet/StrictSigil`). We do this to allow clients to continue to use `Sorbet/StrictSigil` without clashing configurations.

I need to bump the major version for this change because I'm technically breaking public API (the end user needs to change their `.rubocop_todo.yml` to accomodate the cop name change. It's not a huge migration, but since it breaks public API I want us to get in a good habit of bumping the major version. I will include a "migration guide" in the release notes.
