### PR TITLE
Fix bug with root package protections

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    package_protections (1.1.0)
+    package_protections (1.1.1)
       activesupport
       parse_packwerk
       rubocop
@@ -67,7 +67,7 @@ GEM
       parser (>= 3.0.1.1)
     rubocop-rspec (2.8.0)
       rubocop (~> 1.19)
-    rubocop-sorbet (0.6.10)
+    rubocop-sorbet (0.6.11)
       rubocop (>= 0.90.0)
     ruby-progressbar (1.11.0)
     sorbet (0.5.9588)

--- a/lib/package_protections/rubocop_protection_interface.rb
+++ b/lib/package_protections/rubocop_protection_interface.rb
@@ -108,7 +108,7 @@ module PackageProtections
           T.absurd(violation_behavior)
         end
 
-        package.original_package.directory.glob('**/**/*.*').each do |relative_path_to_file|
+        package.original_package.directory.glob(included_globs_for_pack).each do |relative_path_to_file|
           next unless exclude_list.include?(relative_path_to_file.to_s)
 
           file = relative_path_to_file.to_s

--- a/package_protections.gemspec
+++ b/package_protections.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'package_protections'
-  spec.version       = '1.1.0'
+  spec.version       = '1.1.1'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['stephan.hagemann@gusto.com']
   spec.summary       = 'Package protections for Rails apps'

--- a/sorbet/rbi/manual.rbi
+++ b/sorbet/rbi/manual.rbi
@@ -1,0 +1,8 @@
+# typed: true
+
+class Pathname
+  sig do
+    params(p1: T::Array[String], p2: Integer).returns(T::Array[Pathname])
+  end
+  def glob(p1, p2=0, &blk); end
+end


### PR DESCRIPTION
Since the last PR where I started looking at any of a pack's files (and not just the ones it cared about), I had a false positive. The issue was the root package's files "include" files from other packs. To ignore this, we can explicitly pass in the globs we care about when looking at the ignore list.
