### PR TITLE
Replaces static defaults in spec helpers

### DIFF
--- a/lib/package_protections/rspec/application_fixture_helper.rb
+++ b/lib/package_protections/rspec/application_fixture_helper.rb
@@ -20,13 +20,10 @@ module ApplicationFixtureHelper
     global_namespaces: [],
     visible_to: []
   )
-    defaults = {
-      'prevent_this_package_from_violating_its_stated_dependencies' => 'fail_on_new',
-      'prevent_other_packages_from_using_this_packages_internals' => 'fail_on_new',
-      'prevent_this_package_from_exposing_an_untyped_api' => 'fail_on_new',
-      'prevent_this_package_from_creating_other_namespaces' => 'fail_on_new',
-      'prevent_other_packages_from_using_this_package_without_explicit_visibility' => 'fail_never'
-    }
+    defaults = PackageProtections
+      .all
+      .to_h { |p| [p.identifier, p.default_behavior.serialize] }
+
     protections_with_defaults = defaults.merge(protections)
     metadata = { 'protections' => protections_with_defaults }
     if visible_to.any?

--- a/spec/package_protections_spec.rb
+++ b/spec/package_protections_spec.rb
@@ -78,16 +78,15 @@ describe PackageProtections do
         )
       end
 
-      it 'respects the configured protections' do
+      it 'respects the configured protections being empty' do
         PackageProtections.configure do |config|
           config.protections = []
         end
 
         write_package_yml('packs/trees')
+        offenses = PackageProtections.get_offenses(packages: get_packages, new_violations: [])
 
-        expect { PackageProtections.get_offenses(packages: get_packages, new_violations: []) }.to raise_error(PackageProtections::IncorrectPublicApiUsageError) do |e|
-          expect(e.message).to eq 'Invalid configuration for package `packs/trees`. The metadata keys ["prevent_this_package_from_violating_its_stated_dependencies", "prevent_other_packages_from_using_this_packages_internals", "prevent_this_package_from_exposing_an_untyped_api", "prevent_this_package_from_creating_other_namespaces", "prevent_other_packages_from_using_this_package_without_explicit_visibility"] are not valid behaviors under the `protection` metadata namespace. Valid keys are []. See https://github.com/rubyatscale/package_protections#readme for more info'
-        end
+        expect(offenses).to eq([])
       end
     end
 


### PR DESCRIPTION
This change replaces static default failure levels in the spec helper
`write_file` to reference `default_behavior` for each protection.
Without this new protections, including those defined externally, will
have to be present in that default hash.

This makes testing difficult as you need to now additionally specify
every extension in every test. This change makes that dynamic
instead.