### PR TITLE
Simplify namespace protection

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -110,3 +110,6 @@ Layout/FirstArgumentIndentation:
 # This leads to code that is not very readable at times (very long lines)
 Layout/ArgumentAlignment:
   Enabled: false
+
+Style/AccessorGrouping:
+  Enabled: false

--- a/lib/package_protections.rb
+++ b/lib/package_protections.rb
@@ -44,13 +44,19 @@ module PackageProtections
 
     sig { params(blk: T.proc.params(arg0: Private::Configuration).void).void }
     def configure(&blk)
-      yield(Private.config)
+      yield(PackageProtections.config)
     end
   end
 
   sig { returns(T::Array[ProtectionInterface]) }
   def self.all
-    Private.config.protections
+    config.protections
+  end
+
+  sig { returns(Private::Configuration) }
+  def self.config
+    @config = T.let(@config, T.nilable(Private::Configuration))
+    @config ||= Private::Configuration.new
   end
 
   #

--- a/lib/package_protections/private.rb
+++ b/lib/package_protections/private.rb
@@ -17,12 +17,6 @@ module PackageProtections
   module Private
     extend T::Sig
 
-    sig { returns(Private::Configuration) }
-    def self.config
-      @config = T.let(@config, T.nilable(Configuration))
-      @config ||= Private::Configuration.new
-    end
-
     sig do
       params(
         packages: T::Array[ParsePackwerk::Package],
@@ -122,7 +116,7 @@ module PackageProtections
     def self.bust_cache!
       @protected_packages_indexed_by_name = nil
       @private_cop_config = nil
-      config.bust_cache!
+      PackageProtections.config.bust_cache!
     end
 
     sig { params(identifier: Identifier).returns(T::Hash[T.untyped, T.untyped]) }

--- a/lib/package_protections/private/configuration.rb
+++ b/lib/package_protections/private/configuration.rb
@@ -6,11 +6,14 @@ module PackageProtections
       extend T::Sig
 
       sig { params(protections: T::Array[ProtectionInterface]).void }
-      attr_writer :protections
+      attr_writer :protections, :globally_permitted_namespaces
+
+      sig { params(globally_permitted_namespaces: T::Array[String]).void }
 
       sig { void }
       def initialize
         @protections = T.let(default_protections, T::Array[ProtectionInterface])
+        @globally_permitted_namespaces = T.let([], T::Array[String])
       end
 
       sig { returns(T::Array[ProtectionInterface]) }
@@ -18,9 +21,15 @@ module PackageProtections
         @protections
       end
 
+      sig { returns(T::Array[String]) }
+      def globally_permitted_namespaces
+        @globally_permitted_namespaces
+      end
+
       sig { void }
       def bust_cache!
         @protections = default_protections
+        @globally_permitted_namespaces = []
       end
 
       sig { returns(T::Array[ProtectionInterface]) }

--- a/lib/package_protections/private/configuration.rb
+++ b/lib/package_protections/private/configuration.rb
@@ -6,9 +6,10 @@ module PackageProtections
       extend T::Sig
 
       sig { params(protections: T::Array[ProtectionInterface]).void }
-      attr_writer :protections, :globally_permitted_namespaces
+      attr_writer :protections
 
       sig { params(globally_permitted_namespaces: T::Array[String]).void }
+      attr_writer :globally_permitted_namespaces
 
       sig { void }
       def initialize

--- a/lib/rubocop/cop/package_protections/namespaced_under_package_name.rb
+++ b/lib/rubocop/cop/package_protections/namespaced_under_package_name.rb
@@ -231,6 +231,12 @@ module RuboCop
         def root_pathname
           Pathname.pwd
         end
+
+        sig { returns(DesiredZeitwerkApi) }
+        def self.desired_zeitwerk_api
+          @desired_zeitwerk_api ||= T.let(nil, T.nilable(DesiredZeitwerkApi))
+          @desired_zeitwerk_api ||= DesiredZeitwerkApi.new
+        end
       end
     end
   end

--- a/lib/rubocop/cop/package_protections/namespaced_under_package_name.rb
+++ b/lib/rubocop/cop/package_protections/namespaced_under_package_name.rb
@@ -27,6 +27,7 @@ module RuboCop
 
           # This cop only works for files ruby files in `app`
           return if !relative_filename.include?('app/') || relative_filepath.extname != '.rb'
+
           relative_filename = relative_filepath.to_s
           package_for_path = ParsePackwerk.package_from_path(relative_filename)
           return if package_for_path.nil?
@@ -35,9 +36,9 @@ module RuboCop
           return if namespace_context.nil?
 
           allowed_global_namespaces = Set.new([
-            namespace_context.expected_namespace,
-            *::PackageProtections.config.globally_permitted_namespaces
-          ])
+                                                namespace_context.expected_namespace,
+                                                *::PackageProtections.config.globally_permitted_namespaces
+                                              ])
 
           package_name = package_for_path.name
           actual_namespace = namespace_context.current_namespace
@@ -167,8 +168,6 @@ module RuboCop
             See https://go/packwerk_cheatsheet_namespaces for more info.
           MESSAGE
         end
-
-        private
 
         sig { returns(DesiredZeitwerkApi) }
         def self.desired_zeitwerk_api

--- a/lib/rubocop/cop/package_protections/namespaced_under_package_name/desired_zeitwerk_api.rb
+++ b/lib/rubocop/cop/package_protections/namespaced_under_package_name/desired_zeitwerk_api.rb
@@ -1,13 +1,110 @@
+# typed: strict
+
 module RuboCop
   module Cop
     module PackageProtections
-      class NamespacedUnderPackageName
+      class NamespacedUnderPackageName < Base
         #
         # This is a private class that represents API that we would prefer to be available somehow in Zeitwerk.
         #
         class DesiredZeitwerkApi
+          extend T::Sig
 
+          class NamespaceContext < T::Struct
+            const :current_namespace, String
+            const :expected_namespace, String
+            const :expected_filepath, String
+          end
+
+          #
+          # For now, this API includes `package_for_path`
+          # If this were truly zeitwerk API, it wouldn't include any mention of packs and it would likely not need the package at all
+          # Since it could get the actual namespace without knowing anything about packs.
+          # However, we would need to pass to it the desired namespace based on the pack name for it to be able to suggest
+          # a desired filepath.
+          # Likely this means that our own cop should determine the desired namespace and pass that in
+          # and this can determine actual namespace and how to get to expected.
+          #
+          sig { params(relative_filename: String, package_for_path: ParsePackwerk::Package).returns(T.nilable(NamespaceContext)) }
+          def for_file(relative_filename, package_for_path)
+
+            package_name = package_for_path.name
+
+            # Zeitwerk establishes a standard convention by which namespaces are defined.
+            # The package protections namespace checker is coupled to a specific assumption about how auto-loading works.
+            #
+            # Namely, we expect the following autoload paths: `packs/**/app/**/`
+            # Examples:
+            # 1) `packs/package_1/app/public/package_1/my_constant.rb` produces constant `Package1::MyConstant`
+            # 2) `packs/package_1/app/services/package_1/my_service.rb` produces constant `Package1::MyService`
+            # 3) `packs/package_1/app/services/package_1.rb` produces constant `Package1`
+            # 4) `packs/package_1/app/public/package_1.rb` produces constant `Package1`
+            #
+            # Described another way, we expect any part of the directory labeled NAMESPACE to establish a portion of the fully qualified runtime constant:
+            # `packs/**/app/**/NAMESPACE1/NAMESPACE2/[etc]`
+            #
+            # Therefore, for our implementation, we substitute out the non-namespace producing portions of the filename to count the number of namespaces.
+            # Note this will *not work* properly in applications that have different assumptions about autoloading.
+
+            path_without_package_base = relative_filename.gsub(%r{#{package_name}/app/}, '')
+            if path_without_package_base.include?('concerns')
+              autoload_folder_name = path_without_package_base.split('/').first(2).join('/')
+            else
+              autoload_folder_name = path_without_package_base.split('/').first
+            end
+
+            remaining_file_path = path_without_package_base.gsub(%r{\A#{autoload_folder_name}/}, '')
+            actual_namespace = get_actual_namespace(remaining_file_path, package_name)
+
+            if relative_filename.include?('app/')
+              app_or_lib = 'app'
+            elsif relative_filename.include?('lib/')
+              app_or_lib = 'lib'
+            end
+
+            absolute_desired_path = root_pathname.join(
+              package_name,
+              T.must(app_or_lib),
+              T.must(autoload_folder_name),
+              get_package_last_name(package_for_path),
+              remaining_file_path
+            )
+
+            relative_desired_path = absolute_desired_path.relative_path_from(root_pathname)
+
+            NamespaceContext.new(
+              current_namespace: actual_namespace,
+              expected_namespace: get_pack_based_namespace(package_for_path),
+              expected_filepath: relative_desired_path.to_s,
+            )
+          end
+
+          sig { params(pack: ParsePackwerk::Package).returns(String) }
+          def get_pack_based_namespace(pack)
+            get_package_last_name(pack).camelize
+          end
+
+          private
+
+          sig {returns(Pathname)}
+          def root_pathname
+            Pathname.pwd
+          end
+
+          sig { params(pack: ParsePackwerk::Package).returns(String) }
+          def get_package_last_name(pack)
+            T.must(pack.name.split('/').last)
+          end
+
+          sig { params(remaining_file_path: String, package_name: String).returns(String) }
+          def get_actual_namespace(remaining_file_path, package_name)
+            # If the remaining file path is a ruby file (not a directory), then it establishes a global namespace
+            # Otherwise, per Zeitwerk's conventions as listed above, its a directory that establishes another global namespace
+            T.must(remaining_file_path.split('/').first).gsub('.rb', '').camelize
+          end
         end
+
+        private_constant :DesiredZeitwerkApi
       end
     end
   end

--- a/lib/rubocop/cop/package_protections/namespaced_under_package_name/desired_zeitwerk_api.rb
+++ b/lib/rubocop/cop/package_protections/namespaced_under_package_name/desired_zeitwerk_api.rb
@@ -1,0 +1,14 @@
+module RuboCop
+  module Cop
+    module PackageProtections
+      class NamespacedUnderPackageName
+        #
+        # This is a private class that represents API that we would prefer to be available somehow in Zeitwerk.
+        #
+        class DesiredZeitwerkApi
+
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/package_protections/namespaced_under_package_name/desired_zeitwerk_api.rb
+++ b/lib/rubocop/cop/package_protections/namespaced_under_package_name/desired_zeitwerk_api.rb
@@ -27,7 +27,6 @@ module RuboCop
           #
           sig { params(relative_filename: String, package_for_path: ParsePackwerk::Package).returns(T.nilable(NamespaceContext)) }
           def for_file(relative_filename, package_for_path)
-
             package_name = package_for_path.name
 
             # Zeitwerk establishes a standard convention by which namespaces are defined.
@@ -75,7 +74,7 @@ module RuboCop
             NamespaceContext.new(
               current_namespace: actual_namespace,
               expected_namespace: get_pack_based_namespace(package_for_path),
-              expected_filepath: relative_desired_path.to_s,
+              expected_filepath: relative_desired_path.to_s
             )
           end
 
@@ -86,7 +85,7 @@ module RuboCop
 
           private
 
-          sig {returns(Pathname)}
+          sig { returns(Pathname) }
           def root_pathname
             Pathname.pwd
           end

--- a/spec/package_protections_spec.rb
+++ b/spec/package_protections_spec.rb
@@ -668,7 +668,7 @@ describe PackageProtections do
           it 'generates the expected rubocop.yml entries' do
             apples_package_yml_with_namespace_protection_set_to_fail_never
             cop_config = get_resulting_rubocop['PackageProtections/NamespacedUnderPackageName']
-            expect(cop_config).to eq({ 'Enabled' => false })
+            expect(cop_config).to eq({ 'Enabled' => true, 'Include' => ['packs/apples/app/**/*', 'packs/apples/lib/**/*'] })
           end
 
           it 'is implemented by Rubocop' do
@@ -722,12 +722,6 @@ describe PackageProtections do
               expect(cop_config['Include']).to eq(['packs/apples/app/**/*', 'packs/apples/lib/**/*'])
               expect(cop_config['Enabled']).to eq(true)
             end
-
-            it 'retrieves the right rubocop metadata' do
-              apples_package_yml_with_namespace_protection_set_to_fail_on_new
-              private_cop_config = PackageProtections.private_cop_config('prevent_this_package_from_creating_other_namespaces')
-              expect(private_cop_config['packs/apples']).to eq({ 'GlobalNamespaces' => %w[AppleTrees Ciders Apples] })
-            end
           end
 
           it 'is implemented by Rubocop' do
@@ -762,12 +756,6 @@ describe PackageProtections do
                 expect(cop_config['Exclude']).to eq(nil)
                 expect(cop_config['Include']).to eq(['packs/apples/subpack/app/**/*', 'packs/apples/subpack/lib/**/*'])
                 expect(cop_config['Enabled']).to eq(true)
-              end
-
-              it 'retrieves the right rubocop metadata' do
-                apples_package_yml_with_namespace_protection_set_to_fail_on_new
-                private_cop_config = PackageProtections.private_cop_config('prevent_this_package_from_creating_other_namespaces')
-                expect(private_cop_config['packs/apples/subpack']).to eq({ 'GlobalNamespaces' => %w[AppleTrees Ciders Apples] })
               end
             end
 


### PR DESCRIPTION
# Summary

This implements ADR 052 at Gusto which reflects the basic idea that each pack should expose one and only one namespace equal to the packs name and cannot sit in other packs' namespaces.

# Commits

- Change tests to reflect newly desired behavior
- fix tests
- fix attr writers
- make cop typed strict
- add desired zeitwerk API class
- Reorganize some of the complexity
- rubocop
