### PR TITLE
Use autoload when possible to lazily require internal dependencies

### DIFF
--- a/lib/package_protections.rb
+++ b/lib/package_protections.rb
@@ -2,19 +2,16 @@
 
 # typed: strict
 require 'sorbet-runtime'
+
 require 'open3'
 require 'set'
 require 'parse_packwerk'
-require 'rubocop'
-require 'rubocop-sorbet'
 
-#
 # Welcome to PackageProtections!
 # See https://github.com/rubyatscale/package_protections#readme for more info
 #
 # This file is a reference for the available API to `package_protections`, but all implementation details are private
 # (which is why we delegate to `Private` for the actual implementation).
-#
 module PackageProtections
   extend T::Sig
 
@@ -27,17 +24,13 @@ module PackageProtections
   # This is currently the only handled exception that `PackageProtections` will throw.
   class IncorrectPublicApiUsageError < StandardError; end
 
-  require 'package_protections/offense'
-  require 'package_protections/violation_behavior'
-  require 'package_protections/protected_package'
-  require 'package_protections/per_file_violation'
-  require 'package_protections/protection_interface'
-  require 'package_protections/rubocop_protection_interface'
-  require 'package_protections/private'
-
-  # Implementation of rubocop-based protections
-  require 'rubocop/cop/package_protections/namespaced_under_package_name'
-  require 'rubocop/cop/package_protections/typed_public_api'
+  autoload :Offense, 'package_protections/offense'
+  autoload :ViolationBehavior, 'package_protections/violation_behavior'
+  autoload :ProtectedPackage, 'package_protections/protected_package'
+  autoload :PerFileViolation, 'package_protections/per_file_violation'
+  autoload :ProtectionInterface, 'package_protections/protection_interface'
+  autoload :RubocopProtectionInterface, 'package_protections/rubocop_protection_interface'
+  autoload :Private, 'package_protections/private'
 
   class << self
     extend T::Sig
@@ -120,5 +113,11 @@ module PackageProtections
   def self.bust_cache!
     Private.bust_cache!
     RubocopProtectionInterface.bust_rubocop_todo_yml_cache
+  end
+end
+
+module Rubocop
+  module Cop
+    autoload :PackageProtections, 'rubocop/cop/package_protections'
   end
 end

--- a/lib/rubocop/cop/package_protections.rb
+++ b/lib/rubocop/cop/package_protections.rb
@@ -1,0 +1,13 @@
+require 'rubocop'
+require 'rubocop-sorbet'
+
+module Rubocop
+  module Cop
+    module PackageProtections
+      autoload :NamespacedUnderPackageName, 'rubocop/cop/package_protections/namespaced_under_package_name'
+      autoload :TypedPublicApi, 'rubocop/cop/package_protections/typed_public_api'
+    end
+  end
+end
+
+# Implementation of rubocop-based protections


### PR DESCRIPTION
I recently came across [bumbler](https://github.com/nevir/Bumbler) as a tool to track down slow-requiring dependencies in a Rails app.

The default threshold is 100ms, and bumbler reports it taking:

```
❯ bumbler                                                                                                                                                                                                                                              
[###########################################################################################################################################################                                                                                            ]
(189/301)                                                                                                                                                                                                                        
189 of 301 gems required
Slow requires:
    118.90  plaid
    162.70  xero-ruby
    266.35  datadog_api_client
    434.79  package_protections
```

After this PR, it doesn't even show up with 10ms as the threshold 👀 