### PR TITLE
Support zeitwerk custom root directories

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    package_protections (2.2.1)
+    package_protections (2.3.0)
       activesupport
       parse_packwerk
       rubocop

--- a/README.md
+++ b/README.md
@@ -54,21 +54,14 @@ This protection ensures that all files within `app/public` are typed at level `s
 This helps ensure that your package is only creating one namespace (based on folder hierarchy). This helps organize the public API of your pack into one place.
 This protection only looks at files in `packs/your_pack/app` (it ignores spec files).
 This protection is implemented via Rubocop -- expect to see results for this when running `rubocop` however you normally do. To add to the TODO list, add to `.rubocop_todo.yml`
-Lastly – this protection can be configured by setting `global_namespaces` within the `package.yml`, e.g.:
-```
-enforce_privacy: true
-enforce_dependencies: true
-metadata:
-  protections:
-    # ... nothing changes here
-  global_namespaces:
-    - MyNamespace
-    - MyOtherNamespace
-    - MyThirdNamespace
-    # ... etc.
+Lastly – this protection can be configured by setting `globally_permitted_namespaces`, e.g.:
+```ruby
+PackageProtections.configure do |config|
+  config.globally_permitted_namespaces = ['SomeGlobalNamespace']
+end
 ```
 
-It's encouraged to limit the number of global namespaces your package exposes, and to make sure your global namespaces are as specific to your domain as possible.
+If you've worked through all of the TODOs for this cop and are able to set the value to `fail_on_any`, you can also set `automatic_pack_namespace` which will support your pack having one global namespace without extra subdirectories. That is, instead of `packs/foo/app/services/foo/bar.rb`, you can use `packs/foo/app/services/bar.rb` and still have it define `Foo::Bar`. [See the `stimpack` README.md](https://github.com/rubyatscale/stimpack#readme) for more information.
 
 ### `prevent_other_packages_from_using_this_package_without_explicit_visibility`
 *This is only available if your package has `enforce_privacy` set to `true`!*

--- a/lib/package_protections/rspec/application_fixture_helper.rb
+++ b/lib/package_protections/rspec/application_fixture_helper.rb
@@ -18,7 +18,8 @@ module ApplicationFixtureHelper
     enforce_privacy: true,
     protections: {},
     global_namespaces: [],
-    visible_to: []
+    visible_to: [],
+    automatic_pack_namespace: false
   )
     defaults = {
       'prevent_this_package_from_violating_its_stated_dependencies' => 'fail_on_new',
@@ -36,6 +37,8 @@ module ApplicationFixtureHelper
     if global_namespaces.any?
       metadata.merge!('global_namespaces' => global_namespaces)
     end
+
+    metadata.merge!('automatic_pack_namespace' => true) if automatic_pack_namespace
 
     package = ParsePackwerk::Package.new(
       name: pack_name,

--- a/lib/rubocop/cop/package_protections/namespaced_under_package_name.rb
+++ b/lib/rubocop/cop/package_protections/namespaced_under_package_name.rb
@@ -31,6 +31,8 @@ module RuboCop
           relative_filename = relative_filepath.to_s
           package_for_path = ParsePackwerk.package_from_path(relative_filename)
           return if package_for_path.nil?
+          # If a pack is using automatic pack namespaces, this protection is a no-op since zeitwerk will enforce single namespaces in that case.
+          return if package_for_path.metadata['automatic_pack_namespace']
 
           namespace_context = self.class.desired_zeitwerk_api.for_file(relative_filename, package_for_path)
           return if namespace_context.nil?

--- a/package_protections.gemspec
+++ b/package_protections.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'package_protections'
-  spec.version       = '2.2.1'
+  spec.version       = '2.3.0'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['stephan.hagemann@gusto.com']
   spec.summary       = 'Package protections for Rails apps'

--- a/spec/rubocop/cop/namespaced_under_package_name_spec.rb
+++ b/spec/rubocop/cop/namespaced_under_package_name_spec.rb
@@ -377,4 +377,23 @@ RSpec.describe RuboCop::Cop::PackageProtections::NamespacedUnderPackageName do
       it { expect_no_offenses source, Pathname.pwd.join(write_file('packs/fruits/apples/app/models/concerns/apples.rb')).to_s }
     end
   end
+
+  context 'a pack uses custom zeitwerk namespaces' do
+    before do
+      write_package_yml('packs/apples', automatic_pack_namespace: true)
+    end
+
+    context 'when file establishes different namespace' do
+      let(:source) do
+        <<~RUBY
+          module Apples
+            class Tool
+            end
+          end
+        RUBY
+      end
+
+      it { expect_no_offenses source, Pathname.pwd.join(write_file('packs/apples/app/services/tool.rb')).to_s }
+    end
+  end
 end


### PR DESCRIPTION
# Summary

This allows the namespace protection to be compatible with stimpack-implemented custom root directories, which is implemented in https://github.com/rubyatscale/stimpack/pull/37

# Commits
- Ignore packs that use automatic_pack_namespace from namespace protection
- fix readme for namespace protection
- bump version
