### PR TITLE
Move validations into PackageProtections.validate!

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    package_protections (2.5.2)
+    package_protections (2.5.3)
       activesupport
       parse_packwerk
       rubocop
@@ -27,7 +27,7 @@ GEM
     method_source (1.0.0)
     minitest (5.16.3)
     parallel (1.22.1)
-    parse_packwerk (0.12.1)
+    parse_packwerk (0.14.0)
       sorbet-runtime
     parser (3.1.2.1)
       ast (~> 2.4.1)
@@ -68,7 +68,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.21.0)
       parser (>= 3.1.1.0)
-    rubocop-packs (0.0.11)
+    rubocop-packs (0.0.13)
       activesupport
       parse_packwerk
       rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    package_protections (2.5.3)
+    package_protections (3.0.0)
       activesupport
       parse_packwerk
       rubocop

--- a/lib/package_protections.rb
+++ b/lib/package_protections.rb
@@ -109,9 +109,9 @@ module PackageProtections
 
       # Validate that all protections requiring configuration have explicit configuration
       unspecified_protections = valid_identifiers - metadata.keys
-      protections_requiring_explicit_configuration = unspecified_protections.select do |protection_key|
+      protections_requiring_explicit_configuration = unspecified_protections.reject do |protection_key|
         protection = PackageProtections.with_identifier(protection_key)
-        !protection.default_behavior.fail_never?
+        protection.default_behavior.fail_never?
       end
 
       protections_requiring_explicit_configuration.each do |protection_identifier|

--- a/lib/package_protections.rb
+++ b/lib/package_protections.rb
@@ -121,6 +121,7 @@ module PackageProtections
       # Validate that all protections have all preconditions met
       metadata.each do |protection_identifier, value|
         next if !valid_identifiers.include?(protection_identifier)
+
         behavior = ViolationBehavior.from_raw_value(value)
         protection = PackageProtections.with_identifier(protection_identifier)
         unmet_preconditions = protection.unmet_preconditions_for_behavior(behavior, p)

--- a/lib/package_protections.rb
+++ b/lib/package_protections.rb
@@ -91,6 +91,48 @@ module PackageProtections
     ).compact
   end
 
+  sig do
+    returns(T::Array[String])
+  end
+  def self.validate!
+    errors = T.let([], T::Array[String])
+    valid_identifiers = PackageProtections.all.map(&:identifier)
+
+    ParsePackwerk.all.each do |p|
+      metadata = p.metadata['protections'] || {}
+
+      # Validate that there are no invalid keys
+      invalid_identifiers = metadata.keys - valid_identifiers
+      if invalid_identifiers.any?
+        errors << "Invalid configuration for package `#{p.name}`. The metadata keys #{invalid_identifiers.inspect} are not a valid behavior under the `protection` metadata namespace. Valid keys are #{valid_identifiers.inspect}. See https://github.com/rubyatscale/package_protections#readme for more info"
+      end
+
+      # Validate that all protections requiring configuration have explicit configuration
+      unspecified_protections = valid_identifiers - metadata.keys
+      protections_requiring_explicit_configuration = unspecified_protections.select do |protection_key|
+        protection = PackageProtections.with_identifier(protection_key)
+        !protection.default_behavior.fail_never?
+      end
+
+      protections_requiring_explicit_configuration.each do |protection_identifier|
+        errors << "All protections must explicitly set unless their default behavior is `fail_never`. Missing protection #{protection_identifier} for package #{p.name}."
+      end
+
+      # Validate that all protections have all preconditions met
+      metadata.each do |protection_identifier, value|
+        next if !valid_identifiers.include?(protection_identifier)
+        behavior = ViolationBehavior.from_raw_value(value)
+        protection = PackageProtections.with_identifier(protection_identifier)
+        unmet_preconditions = protection.unmet_preconditions_for_behavior(behavior, p)
+        if unmet_preconditions
+          errors << "#{protection_identifier} protection does not have the valid preconditions in #{p.name}. #{unmet_preconditions}. See https://github.com/rubyatscale/package_protections#readme for more info"
+        end
+      end
+    end
+
+    errors
+  end
+
   #
   # PackageProtections.set_defaults! sets any unset protections to their default enforcement
   #

--- a/package_protections.gemspec
+++ b/package_protections.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'package_protections'
-  spec.version       = '2.5.3'
+  spec.version       = '3.0.0'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['stephan.hagemann@gusto.com']
   spec.summary       = 'Package protections for Rails apps'

--- a/package_protections.gemspec
+++ b/package_protections.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'package_protections'
-  spec.version       = '2.5.2'
+  spec.version       = '2.5.3'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['stephan.hagemann@gusto.com']
   spec.summary       = 'Package protections for Rails apps'

--- a/spec/package_protections/protected_package_spec.rb
+++ b/spec/package_protections/protected_package_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe PackageProtections::ProtectedPackage do
       YML
 
       expect(PackageProtections.validate!).to eq([
-        "All protections must explicitly set unless their default behavior is `fail_never`. Missing protection prevent_this_package_from_violating_its_stated_dependencies for package ..",
-        "All protections must explicitly set unless their default behavior is `fail_never`. Missing protection prevent_other_packages_from_using_this_packages_internals for package ..",
-        "All protections must explicitly set unless their default behavior is `fail_never`. Missing protection prevent_this_package_from_exposing_an_untyped_api for package ..",
-        "All protections must explicitly set unless their default behavior is `fail_never`. Missing protection prevent_this_package_from_creating_other_namespaces for package .."
-      ])
+                                                   'All protections must explicitly set unless their default behavior is `fail_never`. Missing protection prevent_this_package_from_violating_its_stated_dependencies for package ..',
+                                                   'All protections must explicitly set unless their default behavior is `fail_never`. Missing protection prevent_other_packages_from_using_this_packages_internals for package ..',
+                                                   'All protections must explicitly set unless their default behavior is `fail_never`. Missing protection prevent_this_package_from_exposing_an_untyped_api for package ..',
+                                                   'All protections must explicitly set unless their default behavior is `fail_never`. Missing protection prevent_this_package_from_creating_other_namespaces for package ..'
+                                                 ])
     end
 
     context 'empty metadata->protections' do
@@ -30,11 +30,11 @@ RSpec.describe PackageProtections::ProtectedPackage do
         YML
 
         expect(PackageProtections.validate!).to eq([
-          "All protections must explicitly set unless their default behavior is `fail_never`. Missing protection prevent_this_package_from_violating_its_stated_dependencies for package ..",
-          "All protections must explicitly set unless their default behavior is `fail_never`. Missing protection prevent_other_packages_from_using_this_packages_internals for package ..",
-          "All protections must explicitly set unless their default behavior is `fail_never`. Missing protection prevent_this_package_from_exposing_an_untyped_api for package ..",
-          "All protections must explicitly set unless their default behavior is `fail_never`. Missing protection prevent_this_package_from_creating_other_namespaces for package .."
-        ])
+                                                     'All protections must explicitly set unless their default behavior is `fail_never`. Missing protection prevent_this_package_from_violating_its_stated_dependencies for package ..',
+                                                     'All protections must explicitly set unless their default behavior is `fail_never`. Missing protection prevent_other_packages_from_using_this_packages_internals for package ..',
+                                                     'All protections must explicitly set unless their default behavior is `fail_never`. Missing protection prevent_this_package_from_exposing_an_untyped_api for package ..',
+                                                     'All protections must explicitly set unless their default behavior is `fail_never`. Missing protection prevent_this_package_from_creating_other_namespaces for package ..'
+                                                   ])
       end
     end
 
@@ -45,7 +45,7 @@ RSpec.describe PackageProtections::ProtectedPackage do
             someprotection: true
       YML
 
-      expect(PackageProtections.validate!).to include "Invalid configuration for package `.`. The metadata keys [\"someprotection\"] are not a valid behavior under the `protection` metadata namespace. Valid keys are [\"prevent_this_package_from_violating_its_stated_dependencies\", \"prevent_other_packages_from_using_this_packages_internals\", \"prevent_this_package_from_exposing_an_untyped_api\", \"prevent_this_package_from_creating_other_namespaces\", \"prevent_other_packages_from_using_this_package_without_explicit_visibility\", \"prevent_this_package_from_exposing_instance_method_public_apis\", \"prevent_this_package_from_exposing_undocumented_public_apis\"]. See https://github.com/rubyatscale/package_protections#readme for more info"
+      expect(PackageProtections.validate!).to include 'Invalid configuration for package `.`. The metadata keys ["someprotection"] are not a valid behavior under the `protection` metadata namespace. Valid keys are ["prevent_this_package_from_violating_its_stated_dependencies", "prevent_other_packages_from_using_this_packages_internals", "prevent_this_package_from_exposing_an_untyped_api", "prevent_this_package_from_creating_other_namespaces", "prevent_other_packages_from_using_this_package_without_explicit_visibility", "prevent_this_package_from_exposing_instance_method_public_apis", "prevent_this_package_from_exposing_undocumented_public_apis"]. See https://github.com/rubyatscale/package_protections#readme for more info'
     end
   end
 

--- a/spec/package_protections/protected_package_spec.rb
+++ b/spec/package_protections/protected_package_spec.rb
@@ -8,44 +8,44 @@ RSpec.describe PackageProtections::ProtectedPackage do
   end
 
   describe 'unspecified protections' do
-    it 'blows up if package has not specified behaviors explicitly for protections with non no-op default behavior' do
+    it 'has a validation error if package has not specified behaviors explicitly for protections with non no-op default behavior' do
       write_file('package.yml', <<~YML.strip)
         enforce_dependencies: false
         enforce_privacy: false
       YML
 
-      expect { PackageProtections::ProtectedPackage.from(packages.find { |p| p.name == ParsePackwerk::ROOT_PACKAGE_NAME }) }.to raise_error do |e|
-        expect(e).to be_a PackageProtections::IncorrectPublicApiUsageError
-        error_message = 'All protections must explicitly set unless their default behavior is `fail_never`. Missing protections: prevent_this_package_from_violating_its_stated_dependencies, prevent_other_packages_from_using_this_packages_internals, prevent_this_package_from_exposing_an_untyped_api, prevent_this_package_from_creating_other_namespaces'
-        expect(e.message).to include error_message
-      end
+      expect(PackageProtections.validate!).to eq([
+        "All protections must explicitly set unless their default behavior is `fail_never`. Missing protection prevent_this_package_from_violating_its_stated_dependencies for package ..",
+        "All protections must explicitly set unless their default behavior is `fail_never`. Missing protection prevent_other_packages_from_using_this_packages_internals for package ..",
+        "All protections must explicitly set unless their default behavior is `fail_never`. Missing protection prevent_this_package_from_exposing_an_untyped_api for package ..",
+        "All protections must explicitly set unless their default behavior is `fail_never`. Missing protection prevent_this_package_from_creating_other_namespaces for package .."
+      ])
     end
 
     context 'empty metadata->protections' do
-      it 'blows up if package has not specified behaviors explicitly for protections with non no-op default behavior in case of empty metadata->protections' do
+      it 'has a validation error if package has not specified behaviors explicitly for protections with non no-op default behavior in case of empty metadata->protections' do
         write_file('package.yml', <<~YML.strip)
           metadata:
             protections: {}
         YML
 
-        expect { PackageProtections::ProtectedPackage.from(packages.find { |p| p.name == ParsePackwerk::ROOT_PACKAGE_NAME }) }.to raise_error do |e|
-          expect(e).to be_a PackageProtections::IncorrectPublicApiUsageError
-          error_message = 'All protections must explicitly set unless their default behavior is `fail_never`. Missing protections: prevent_this_package_from_violating_its_stated_dependencies, prevent_other_packages_from_using_this_packages_internals, prevent_this_package_from_exposing_an_untyped_api, prevent_this_package_from_creating_other_namespaces'
-          expect(e.message).to include error_message
-        end
+        expect(PackageProtections.validate!).to eq([
+          "All protections must explicitly set unless their default behavior is `fail_never`. Missing protection prevent_this_package_from_violating_its_stated_dependencies for package ..",
+          "All protections must explicitly set unless their default behavior is `fail_never`. Missing protection prevent_other_packages_from_using_this_packages_internals for package ..",
+          "All protections must explicitly set unless their default behavior is `fail_never`. Missing protection prevent_this_package_from_exposing_an_untyped_api for package ..",
+          "All protections must explicitly set unless their default behavior is `fail_never`. Missing protection prevent_this_package_from_creating_other_namespaces for package .."
+        ])
       end
     end
 
-    it 'blows up if metadata->protections contain unknown keys' do
+    it 'has a validation error if metadata->protections contain unknown keys' do
       write_file('package.yml', <<~YML.strip)
         metadata:
           protections:
             someprotection: true
       YML
 
-      expect {
-        PackageProtections::ProtectedPackage.from(packages.find { |p| p.name == ParsePackwerk::ROOT_PACKAGE_NAME })
-      }.to raise_exception(PackageProtections::IncorrectPublicApiUsageError)
+      expect(PackageProtections.validate!).to include "Invalid configuration for package `.`. The metadata keys [\"someprotection\"] are not a valid behavior under the `protection` metadata namespace. Valid keys are [\"prevent_this_package_from_violating_its_stated_dependencies\", \"prevent_other_packages_from_using_this_packages_internals\", \"prevent_this_package_from_exposing_an_untyped_api\", \"prevent_this_package_from_creating_other_namespaces\", \"prevent_other_packages_from_using_this_package_without_explicit_visibility\", \"prevent_this_package_from_exposing_instance_method_public_apis\", \"prevent_this_package_from_exposing_undocumented_public_apis\"]. See https://github.com/rubyatscale/package_protections#readme for more info"
     end
   end
 

--- a/spec/package_protections_spec.rb
+++ b/spec/package_protections_spec.rb
@@ -40,7 +40,7 @@ describe PackageProtections do
                             'prevent_other_packages_from_using_this_packages_internalsTYPOTYPO!!' => 'something'
                           })
 
-        expect(PackageProtections.validate!).to eq(["Invalid configuration for package `.`. The metadata keys [\"some_misconfigured_key\", \"prevent_other_packages_from_using_this_packages_internalsTYPOTYPO!!\"] are not a valid behavior under the `protection` metadata namespace. Valid keys are [\"prevent_this_package_from_violating_its_stated_dependencies\", \"prevent_other_packages_from_using_this_packages_internals\", \"prevent_this_package_from_exposing_an_untyped_api\", \"prevent_this_package_from_creating_other_namespaces\", \"prevent_other_packages_from_using_this_package_without_explicit_visibility\", \"prevent_this_package_from_exposing_instance_method_public_apis\", \"prevent_this_package_from_exposing_undocumented_public_apis\"]. See https://github.com/rubyatscale/package_protections#readme for more info"])
+        expect(PackageProtections.validate!).to eq(['Invalid configuration for package `.`. The metadata keys ["some_misconfigured_key", "prevent_other_packages_from_using_this_packages_internalsTYPOTYPO!!"] are not a valid behavior under the `protection` metadata namespace. Valid keys are ["prevent_this_package_from_violating_its_stated_dependencies", "prevent_other_packages_from_using_this_packages_internals", "prevent_this_package_from_exposing_an_untyped_api", "prevent_this_package_from_creating_other_namespaces", "prevent_other_packages_from_using_this_package_without_explicit_visibility", "prevent_this_package_from_exposing_instance_method_public_apis", "prevent_this_package_from_exposing_undocumented_public_apis"]. See https://github.com/rubyatscale/package_protections#readme for more info'])
       end
 
       it 'raises on incorrect protection configuration values' do
@@ -87,7 +87,7 @@ describe PackageProtections do
         end
 
         write_package_yml('packs/trees')
-        expect(PackageProtections.validate!).to eq ["Invalid configuration for package `packs/trees`. The metadata keys [\"prevent_this_package_from_violating_its_stated_dependencies\", \"prevent_other_packages_from_using_this_packages_internals\", \"prevent_this_package_from_exposing_an_untyped_api\", \"prevent_this_package_from_creating_other_namespaces\", \"prevent_other_packages_from_using_this_package_without_explicit_visibility\", \"prevent_this_package_from_exposing_instance_method_public_apis\"] are not a valid behavior under the `protection` metadata namespace. Valid keys are []. See https://github.com/rubyatscale/package_protections#readme for more info"]
+        expect(PackageProtections.validate!).to eq ['Invalid configuration for package `packs/trees`. The metadata keys ["prevent_this_package_from_violating_its_stated_dependencies", "prevent_other_packages_from_using_this_packages_internals", "prevent_this_package_from_exposing_an_untyped_api", "prevent_this_package_from_creating_other_namespaces", "prevent_other_packages_from_using_this_package_without_explicit_visibility", "prevent_this_package_from_exposing_instance_method_public_apis"] are not a valid behavior under the `protection` metadata namespace. Valid keys are []. See https://github.com/rubyatscale/package_protections#readme for more info']
       end
     end
 
@@ -143,7 +143,7 @@ describe PackageProtections do
               enforce_dependencies: false,
               protections: { 'prevent_this_package_from_violating_its_stated_dependencies' => 'fail_on_any' })
 
-            expect(PackageProtections.validate!).to eq ["prevent_this_package_from_violating_its_stated_dependencies protection does not have the valid preconditions in packs/apples. Package packs/apples must have `enforce_dependencies: true` to use this protection. See https://github.com/rubyatscale/package_protections#readme for more info"]
+            expect(PackageProtections.validate!).to eq ['prevent_this_package_from_violating_its_stated_dependencies protection does not have the valid preconditions in packs/apples. Package packs/apples must have `enforce_dependencies: true` to use this protection. See https://github.com/rubyatscale/package_protections#readme for more info']
           end
 
           it 'fails when this package newly depends on another package implicitly from a new file' do
@@ -198,7 +198,7 @@ describe PackageProtections do
               enforce_dependencies: false,
               protections: { 'prevent_this_package_from_violating_its_stated_dependencies' => 'fail_on_any' })
 
-            expect(PackageProtections.validate!).to eq ["prevent_this_package_from_violating_its_stated_dependencies protection does not have the valid preconditions in packs/apples. Package packs/apples must have `enforce_dependencies: true` to use this protection. See https://github.com/rubyatscale/package_protections#readme for more info"]
+            expect(PackageProtections.validate!).to eq ['prevent_this_package_from_violating_its_stated_dependencies protection does not have the valid preconditions in packs/apples. Package packs/apples must have `enforce_dependencies: true` to use this protection. See https://github.com/rubyatscale/package_protections#readme for more info']
           end
 
           it 'fails when this package depends on another package implicitly' do
@@ -861,7 +861,7 @@ describe PackageProtections do
             let(:apples_visible_to) { ['packs/some_other_pack'] }
 
             it 'has a validation error' do
-              expect(PackageProtections.validate!).to eq(["prevent_other_packages_from_using_this_package_without_explicit_visibility protection does not have the valid preconditions in packs/apples. Invalid configuration for package `packs/apples`. `prevent_other_packages_from_using_this_package_without_explicit_visibility` must be turned on to use `visible_to` configuration.. See https://github.com/rubyatscale/package_protections#readme for more info"])
+              expect(PackageProtections.validate!).to eq(['prevent_other_packages_from_using_this_package_without_explicit_visibility protection does not have the valid preconditions in packs/apples. Invalid configuration for package `packs/apples`. `prevent_other_packages_from_using_this_package_without_explicit_visibility` must be turned on to use `visible_to` configuration.. See https://github.com/rubyatscale/package_protections#readme for more info'])
             end
           end
 
@@ -921,9 +921,9 @@ describe PackageProtections do
                 enforce_privacy: false,
                 protections: { 'prevent_other_packages_from_using_this_package_without_explicit_visibility' => 'fail_on_new' })
               expect(PackageProtections.validate!).to eq([
-                "prevent_other_packages_from_using_this_packages_internals protection does not have the valid preconditions in packs/apples. Package packs/apples must have `enforce_privacy: true` to use this protection. See https://github.com/rubyatscale/package_protections#readme for more info",
-                "prevent_other_packages_from_using_this_package_without_explicit_visibility protection does not have the valid preconditions in packs/apples. Package packs/apples must have `enforce_privacy: true` to use this protection. See https://github.com/rubyatscale/package_protections#readme for more info"
-              ])
+                                                           'prevent_other_packages_from_using_this_packages_internals protection does not have the valid preconditions in packs/apples. Package packs/apples must have `enforce_privacy: true` to use this protection. See https://github.com/rubyatscale/package_protections#readme for more info',
+                                                           'prevent_other_packages_from_using_this_package_without_explicit_visibility protection does not have the valid preconditions in packs/apples. Package packs/apples must have `enforce_privacy: true` to use this protection. See https://github.com/rubyatscale/package_protections#readme for more info'
+                                                         ])
             end
           end
 
@@ -1436,7 +1436,7 @@ describe PackageProtections do
           context 'package has no README.md' do
             it 'has a validation error' do
               apples_package_yml_with_api_documentation_protection_set_to_fail_on_new
-              expect(PackageProtections.validate!).to eq(["prevent_this_package_from_exposing_undocumented_public_apis protection does not have the valid preconditions in packs/apples. This package must have a readme at packs/apples/README.md to use this protection. See https://github.com/rubyatscale/package_protections#readme for more info"])
+              expect(PackageProtections.validate!).to eq(['prevent_this_package_from_exposing_undocumented_public_apis protection does not have the valid preconditions in packs/apples. This package must have a readme at packs/apples/README.md to use this protection. See https://github.com/rubyatscale/package_protections#readme for more info'])
             end
           end
 

--- a/spec/package_protections_spec.rb
+++ b/spec/package_protections_spec.rb
@@ -40,11 +40,7 @@ describe PackageProtections do
                             'prevent_other_packages_from_using_this_packages_internalsTYPOTYPO!!' => 'something'
                           })
 
-        expect { PackageProtections.get_offenses(packages: get_packages, new_violations: []) }.to raise_error do |e|
-          expect(e).to be_a PackageProtections::IncorrectPublicApiUsageError
-          error_message = 'Invalid configuration for package `.`. The metadata keys ["some_misconfigured_key", "prevent_other_packages_from_using_this_packages_internalsTYPOTYPO!!"] are not valid behaviors under the `protection` metadata namespace. Valid keys are'
-          expect(e.message).to include error_message
-        end
+        expect(PackageProtections.validate!).to eq(["Invalid configuration for package `.`. The metadata keys [\"some_misconfigured_key\", \"prevent_other_packages_from_using_this_packages_internalsTYPOTYPO!!\"] are not a valid behavior under the `protection` metadata namespace. Valid keys are [\"prevent_this_package_from_violating_its_stated_dependencies\", \"prevent_other_packages_from_using_this_packages_internals\", \"prevent_this_package_from_exposing_an_untyped_api\", \"prevent_this_package_from_creating_other_namespaces\", \"prevent_other_packages_from_using_this_package_without_explicit_visibility\", \"prevent_this_package_from_exposing_instance_method_public_apis\", \"prevent_this_package_from_exposing_undocumented_public_apis\"]. See https://github.com/rubyatscale/package_protections#readme for more info"])
       end
 
       it 'raises on incorrect protection configuration values' do
@@ -91,10 +87,7 @@ describe PackageProtections do
         end
 
         write_package_yml('packs/trees')
-
-        expect { PackageProtections.get_offenses(packages: get_packages, new_violations: []) }.to raise_error(PackageProtections::IncorrectPublicApiUsageError) do |e|
-          expect(e.message).to eq 'Invalid configuration for package `packs/trees`. The metadata keys ["prevent_this_package_from_violating_its_stated_dependencies", "prevent_other_packages_from_using_this_packages_internals", "prevent_this_package_from_exposing_an_untyped_api", "prevent_this_package_from_creating_other_namespaces", "prevent_other_packages_from_using_this_package_without_explicit_visibility", "prevent_this_package_from_exposing_instance_method_public_apis"] are not valid behaviors under the `protection` metadata namespace. Valid keys are []. See https://github.com/rubyatscale/package_protections#readme for more info'
-        end
+        expect(PackageProtections.validate!).to eq ["Invalid configuration for package `packs/trees`. The metadata keys [\"prevent_this_package_from_violating_its_stated_dependencies\", \"prevent_other_packages_from_using_this_packages_internals\", \"prevent_this_package_from_exposing_an_untyped_api\", \"prevent_this_package_from_creating_other_namespaces\", \"prevent_other_packages_from_using_this_package_without_explicit_visibility\", \"prevent_this_package_from_exposing_instance_method_public_apis\"] are not a valid behavior under the `protection` metadata namespace. Valid keys are []. See https://github.com/rubyatscale/package_protections#readme for more info"]
       end
     end
 
@@ -145,14 +138,12 @@ describe PackageProtections do
               protections: { 'prevent_this_package_from_violating_its_stated_dependencies' => 'fail_on_new' })
           end
 
-          it 'blows up on missing "enforce_dependencies: true" precondition' do
+          it 'has a validation error on missing "enforce_dependencies: true" precondition' do
             write_package_yml('packs/apples',
               enforce_dependencies: false,
               protections: { 'prevent_this_package_from_violating_its_stated_dependencies' => 'fail_on_any' })
 
-            expect {
-              PackageProtections.get_offenses(packages: get_packages, new_violations: [])
-            }.to raise_exception(PackageProtections::IncorrectPublicApiUsageError)
+            expect(PackageProtections.validate!).to eq ["prevent_this_package_from_violating_its_stated_dependencies protection does not have the valid preconditions in packs/apples. Package packs/apples must have `enforce_dependencies: true` to use this protection. See https://github.com/rubyatscale/package_protections#readme for more info"]
           end
 
           it 'fails when this package newly depends on another package implicitly from a new file' do
@@ -207,9 +198,7 @@ describe PackageProtections do
               enforce_dependencies: false,
               protections: { 'prevent_this_package_from_violating_its_stated_dependencies' => 'fail_on_any' })
 
-            expect {
-              PackageProtections.get_offenses(packages: get_packages, new_violations: [])
-            }.to raise_exception(PackageProtections::IncorrectPublicApiUsageError)
+            expect(PackageProtections.validate!).to eq ["prevent_this_package_from_violating_its_stated_dependencies protection does not have the valid preconditions in packs/apples. Package packs/apples must have `enforce_dependencies: true` to use this protection. See https://github.com/rubyatscale/package_protections#readme for more info"]
           end
 
           it 'fails when this package depends on another package implicitly' do
@@ -871,12 +860,8 @@ describe PackageProtections do
           context 'visible to metadata is set but protection is fail_on_never' do
             let(:apples_visible_to) { ['packs/some_other_pack'] }
 
-            it 'blows up due to invalid precondition' do
-              expect { PackageProtections.get_offenses(packages: get_packages, new_violations: []) }.to raise_error do |e|
-                expect(e).to be_a PackageProtections::IncorrectPublicApiUsageError
-                error_message = 'Invalid configuration for package `packs/apples`. `prevent_other_packages_from_using_this_package_without_explicit_visibility` must be turned on to use `visible_to` configuration.'
-                expect(e.message).to include error_message
-              end
+            it 'has a validation error' do
+              expect(PackageProtections.validate!).to eq(["prevent_other_packages_from_using_this_package_without_explicit_visibility protection does not have the valid preconditions in packs/apples. Invalid configuration for package `packs/apples`. `prevent_other_packages_from_using_this_package_without_explicit_visibility` must be turned on to use `visible_to` configuration.. See https://github.com/rubyatscale/package_protections#readme for more info"])
             end
           end
 
@@ -931,16 +916,14 @@ describe PackageProtections do
           context 'enforce_dependencies is false' do
             let(:apples_visible_to) { [] }
 
-            it 'blows up due to incorrect precondition' do
+            it 'has a validation error' do
               write_package_yml('packs/apples',
                 enforce_privacy: false,
                 protections: { 'prevent_other_packages_from_using_this_package_without_explicit_visibility' => 'fail_on_new' })
-
-              expect { PackageProtections.get_offenses(packages: get_packages, new_violations: []) }.to raise_error do |e|
-                expect(e).to be_a PackageProtections::IncorrectPublicApiUsageError
-                error_message = 'Package packs/apples must have `enforce_privacy: true` to use this protection'
-                expect(e.message).to include error_message
-              end
+              expect(PackageProtections.validate!).to eq([
+                "prevent_other_packages_from_using_this_packages_internals protection does not have the valid preconditions in packs/apples. Package packs/apples must have `enforce_privacy: true` to use this protection. See https://github.com/rubyatscale/package_protections#readme for more info",
+                "prevent_other_packages_from_using_this_package_without_explicit_visibility protection does not have the valid preconditions in packs/apples. Package packs/apples must have `enforce_privacy: true` to use this protection. See https://github.com/rubyatscale/package_protections#readme for more info"
+              ])
             end
           end
 
@@ -1451,12 +1434,9 @@ describe PackageProtections do
           end
 
           context 'package has no README.md' do
-            it 'generates the expected rubocop.yml entries' do
+            it 'has a validation error' do
               apples_package_yml_with_api_documentation_protection_set_to_fail_on_new
-              expect { get_resulting_rubocop['PackageProtections/RequireDocumentedPublicApis'] }.to raise_error do |e|
-                expect(e).to be_a PackageProtections::IncorrectPublicApiUsageError
-                expect(e.message).to eq 'prevent_this_package_from_exposing_undocumented_public_apis protection does not have the valid preconditions. This package must have a readme at packs/apples/README.md to use this protection. See https://github.com/rubyatscale/package_protections#readme for more info'
-              end
+              expect(PackageProtections.validate!).to eq(["prevent_this_package_from_exposing_undocumented_public_apis protection does not have the valid preconditions in packs/apples. This package must have a readme at packs/apples/README.md to use this protection. See https://github.com/rubyatscale/package_protections#readme for more info"])
             end
           end
 


### PR DESCRIPTION
There are many validations that show up to the user when we use `PackageProtections` APIs like `PackageProtections::ProtectedPackage.from(...)`.

These validations all require that the user set up `PackageProtections` up correctly.

As we move away from `package_proteections` and to `rubocop-packs`, we want to allow packs to opt-out of package protections validations more easily.
To do that, we move all validations into one place. This will also stop validations from happening during `modularization_statistics` execution, so users can use `modularization_statistics` without having configured `package_protections`.
