### PR TITLE
Remove custom cop_configs on namespace protection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    package_protections (3.1.0)
+    package_protections (3.2.0)
       activesupport
       parse_packwerk
       rubocop
@@ -68,7 +68,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.21.0)
       parser (>= 3.1.1.0)
-    rubocop-packs (0.0.14)
+    rubocop-packs (0.0.15)
       activesupport
       parse_packwerk
       rubocop

--- a/lib/rubocop/cop/package_protections/namespaced_under_package_name.rb
+++ b/lib/rubocop/cop/package_protections/namespaced_under_package_name.rb
@@ -10,36 +10,6 @@ module RuboCop
         extend T::Sig
         include ::PackageProtections::RubocopProtectionInterface
 
-        # We override `cop_configs` for this protection.
-        # The default behavior disables cops when a package has turned off a protection.
-        # However: namespace violations can occur even when one package has TURNED OFF their namespace protection
-        # but another package has it turned on. Therefore, all packages must always be opted in no matter what.
-        #
-        sig do
-          params(packages: T::Array[::PackageProtections::ProtectedPackage])
-          .returns(T::Array[::PackageProtections::RubocopProtectionInterface::CopConfig])
-        end
-        def cop_configs(packages)
-          include_packs = T.let([], T::Array[String])
-          packages.each do |p|
-            enabled_for_pack = !p.violation_behavior_for(NamespacedUnderPackageName::IDENTIFIER).fail_never?
-            if enabled_for_pack
-              include_packs << p.name
-            end
-          end
-
-          [
-            ::PackageProtections::RubocopProtectionInterface::CopConfig.new(
-              name: cop_name,
-              enabled: include_packs.any?,
-              metadata: {
-                'IncludePacks' => include_packs,
-                'GloballyPermittedNamespaces' => ::RuboCop::Packs.config.globally_permitted_namespaces
-              }
-            )
-          ]
-        end
-
         sig { override.returns(T::Array[String]) }
         def included_globs_for_pack
           [

--- a/package_protections.gemspec
+++ b/package_protections.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'package_protections'
-  spec.version       = '3.1.0'
+  spec.version       = '3.2.0'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['stephan.hagemann@gusto.com']
   spec.summary       = 'Package protections for Rails apps'

--- a/spec/package_protections_spec.rb
+++ b/spec/package_protections_spec.rb
@@ -689,7 +689,7 @@ describe PackageProtections do
               apples_package_yml_with_namespace_protection_set_to_fail_on_new
               cop_config = get_resulting_rubocop['PackageProtections/NamespacedUnderPackageName']
               expect(cop_config['Exclude']).to eq(nil)
-              expect(cop_config['Include']).to eq(["packs/apples/app/**/*", "packs/apples/lib/**/*"])
+              expect(cop_config['Include']).to eq(['packs/apples/app/**/*', 'packs/apples/lib/**/*'])
             end
           end
 
@@ -700,7 +700,7 @@ describe PackageProtections do
               apples_package_yml_with_namespace_protection_set_to_fail_on_new
               cop_config = get_resulting_rubocop['PackageProtections/NamespacedUnderPackageName']
               expect(cop_config['Exclude']).to eq(nil)
-              expect(cop_config['Include']).to eq(["packs/apples/app/**/*", "packs/apples/lib/**/*"])
+              expect(cop_config['Include']).to eq(['packs/apples/app/**/*', 'packs/apples/lib/**/*'])
               expect(cop_config['Enabled']).to eq(true)
             end
           end
@@ -724,7 +724,7 @@ describe PackageProtections do
                 cop_config = get_resulting_rubocop['PackageProtections/NamespacedUnderPackageName']
                 expect(cop_config['Exclude']).to eq(nil)
                 expect(cop_config['Enabled']).to eq(true)
-                expect(cop_config['Include']).to eq(["packs/apples/subpack/app/**/*", "packs/apples/subpack/lib/**/*"])
+                expect(cop_config['Include']).to eq(['packs/apples/subpack/app/**/*', 'packs/apples/subpack/lib/**/*'])
               end
             end
 
@@ -736,7 +736,7 @@ describe PackageProtections do
                 cop_config = get_resulting_rubocop['PackageProtections/NamespacedUnderPackageName']
                 expect(cop_config['Exclude']).to eq(nil)
                 expect(cop_config['Enabled']).to eq(true)
-                expect(cop_config['Include']).to eq(["packs/apples/subpack/app/**/*", "packs/apples/subpack/lib/**/*"])
+                expect(cop_config['Include']).to eq(['packs/apples/subpack/app/**/*', 'packs/apples/subpack/lib/**/*'])
               end
             end
 

--- a/spec/package_protections_spec.rb
+++ b/spec/package_protections_spec.rb
@@ -650,7 +650,7 @@ describe PackageProtections do
           it 'generates the expected rubocop.yml entries' do
             apples_package_yml_with_namespace_protection_set_to_fail_never
             cop_config = get_resulting_rubocop['PackageProtections/NamespacedUnderPackageName']
-            expect(cop_config).to eq({ 'Enabled' => false, 'GloballyPermittedNamespaces' => [], 'IncludePacks' => [] })
+            expect(cop_config).to eq({ 'Enabled' => false })
           end
 
           it 'is implemented by Rubocop' do
@@ -689,9 +689,7 @@ describe PackageProtections do
               apples_package_yml_with_namespace_protection_set_to_fail_on_new
               cop_config = get_resulting_rubocop['PackageProtections/NamespacedUnderPackageName']
               expect(cop_config['Exclude']).to eq(nil)
-              expect(cop_config['Include']).to eq(nil)
-              expect(cop_config['IncludePacks']).to eq(['packs/apples'])
-              expect(cop_config['GloballyPermittedNamespaces']).to eq([])
+              expect(cop_config['Include']).to eq(["packs/apples/app/**/*", "packs/apples/lib/**/*"])
             end
           end
 
@@ -702,10 +700,8 @@ describe PackageProtections do
               apples_package_yml_with_namespace_protection_set_to_fail_on_new
               cop_config = get_resulting_rubocop['PackageProtections/NamespacedUnderPackageName']
               expect(cop_config['Exclude']).to eq(nil)
-              expect(cop_config['Include']).to eq(nil)
-              expect(cop_config['IncludePacks']).to eq(['packs/apples'])
+              expect(cop_config['Include']).to eq(["packs/apples/app/**/*", "packs/apples/lib/**/*"])
               expect(cop_config['Enabled']).to eq(true)
-              expect(cop_config['GloballyPermittedNamespaces']).to eq(%w[AppleTrees Ciders Apples])
             end
           end
 
@@ -728,9 +724,7 @@ describe PackageProtections do
                 cop_config = get_resulting_rubocop['PackageProtections/NamespacedUnderPackageName']
                 expect(cop_config['Exclude']).to eq(nil)
                 expect(cop_config['Enabled']).to eq(true)
-                expect(cop_config['Include']).to eq(nil)
-                expect(cop_config['IncludePacks']).to eq(['packs/apples/subpack'])
-                expect(cop_config['GloballyPermittedNamespaces']).to eq([])
+                expect(cop_config['Include']).to eq(["packs/apples/subpack/app/**/*", "packs/apples/subpack/lib/**/*"])
               end
             end
 
@@ -742,9 +736,7 @@ describe PackageProtections do
                 cop_config = get_resulting_rubocop['PackageProtections/NamespacedUnderPackageName']
                 expect(cop_config['Exclude']).to eq(nil)
                 expect(cop_config['Enabled']).to eq(true)
-                expect(cop_config['Include']).to eq(nil)
-                expect(cop_config['IncludePacks']).to eq(['packs/apples/subpack'])
-                expect(cop_config['GloballyPermittedNamespaces']).to eq(%w[AppleTrees Ciders Apples])
+                expect(cop_config['Include']).to eq(["packs/apples/subpack/app/**/*", "packs/apples/subpack/lib/**/*"])
               end
             end
 


### PR DESCRIPTION
We need to ensure that this cop only runs for packages that explicitly enable it now that we are no longer supporting inbound namespace protection within this cop.
